### PR TITLE
gui/Makefile fix, change ordering of linker options

### DIFF
--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CC      = g++
 # Specifies compilator options
 CFLAGS  = `wx-config --cxxflags`
 LDFLAGS = `wx-config --libs`
-LDLIBS  = -lusb -lm -lk8055
+LDLIBS  = -lm -lk8055 `libusb-config --libs` 
 PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
@@ -22,7 +22,7 @@ all: $(PROG)
 
 # Compilation and link
 $(PROG): $(OBJS)
-	$(CC) $(LDFLAGS) -o $(PROG) $(OBJS) $(LDLIBS)
+	$(CC) -o $(PROG) $(OBJS) $(LDLIBS) $(LDFLAGS)
 
 .cpp.o:
 	$(CC)   $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
gui/Makefile fix, change ordering of linker options

When trying to compile on my Ubuntu 12.04 LTE system, I received a lot of linker errors.
After changing the order of linker options make k8055gui succeeded 
and the gui works on my system. If no degradation on wheezy is observed, I propose to integrate my bug fix.

Thanks for your great work!

Andreas
